### PR TITLE
Update 'new subnet' to 'new route table'

### DIFF
--- a/assignments/assignment-5.adoc
+++ b/assignments/assignment-5.adoc
@@ -108,7 +108,7 @@ identifier. Make sure you save the updated route table when you are done.
 image:../images/assignment5/route-table.png["600","600"]
 
 Your new route table isn't associated with any subnets so it isn't actually doing
-anything yet. Click on the *subnet associations* for the new subnet and edit
+anything yet. Click on the *subnet associations* for the new route table and edit
 the current properties by adding the `infrastructure-public` subnet to the
 routing table. Save your work.
 


### PR DESCRIPTION
I noticed this as I was going through assignment #5 - I think this should be 'new route table': 

Click on the subnet associations for the new _**subnet**_ and edit the current properties by adding the infrastructure-public subnet to the routing table. Save your work.