### PR TITLE
Update week-6-autoscaling.adoc

### DIFF
--- a/hands-on/week-6-autoscaling.adoc
+++ b/hands-on/week-6-autoscaling.adoc
@@ -83,7 +83,7 @@ Create an Application Elastic Load Balancer with the following properties:
 * Listen on port 80 (http)
 * Perform a health check on port 80 to the URL endpoint: `/`
 * ELB is associated with the `eco-elb-sg` security group.
-  ** Allows port 80 (http) traffice from the Internet
+  ** Allows port 80 (http) traffic from the Internet
 * Setup a target group called `ecotech-webservers`, but don't associate any EC2 instances
 with the target group.
 
@@ -94,7 +94,7 @@ Create an EC2 autoscaling group configuration called `ecotech-asg` which runs 3 
 autoscaling group should use a launch configuration with the following properties:
 
 * t2.micro instance size
-* Latest Amazon Linux AMI
+* Latest version of Amazon Linux AMI 
 * 10GB root volume storage size
 * Instances are named `ecoweb`
 * The instances will run in the ecotech-vpc


### PR DESCRIPTION
There was some confusion about whether to use the similarly named "Amazon Linux 2 LTS Candidate AMI" instead of the Amazon Linux AMI.